### PR TITLE
add bug report documentation with examples for frontend and backend

### DIFF
--- a/bug-report-docs/PlantillaBug.md
+++ b/bug-report-docs/PlantillaBug.md
@@ -1,0 +1,51 @@
+# Bug Report 
+
+## Información General
+
+| Campo                   | Detalle                                                        |
+|-------------------------|----------------------------------------------------------------|
+| **Reportado por**       | Julian Rojas                                               |
+| **Fecha y Hora**        | 06/27/2024 - 11:00 PM                                          |
+| **Área del Problema**   | Gestión de Becas                                               |
+| **Título del Problema** | Los subtítulos al entrar a un problema no desaparecen cuando no tienen nada de contenido dentro |
+| **Archivos Adjuntos**   | Entrada, Salida, Restricciones, Explicación                   |
+| **Reproducibilidad**    | Siempre                                                        |
+| **Hora de Ocurrencia**  | 06/27/2024 - 11:00 PM                                          |
+| **URL Exacta**          | https://upb-forces-qa.vercel.app/#/                            |
+| **Versión de Compilación** | 1.0.0                                                      |
+
+---
+
+## Detalles del Bug
+
+| Acción Realizada | Mensaje de Error                  |
+|------------------|-----------------------------------|
+| Se verificó que los subtítulos como “Entrada”, “Salida”, etc., no aparecen en caso de no tener nada dentro de su body al crear el problema. | No aparece ningún mensaje de error. |
+
+| Resultado Esperado | Resultado Real |
+|--------------------|----------------|
+| Según las instrucciones de la tarea, al no tener nada dentro de su body, los subtítulos no deberían mostrarse. | Los subtítulos aparecen en los detalles del problema incluso al estar vacíos en sus bodies. |
+
+---
+
+## Clasificación
+
+| Frecuencia    | Prioridad | Tipo de Defecto |
+|---------------|-----------|-----------------|
+| ☑️ Cada vez   | ☑️ Crítico | ☑️ Frontend     |
+
+---
+
+## Pasos para Replicar el Bug
+
+1. Logearse en la página.
+2. Crear un problema con los elementos Entrada, Salida y Restricciones vacíos.
+3. Guardar el problema.
+4. Ir al detalle desde la sección "Problemas".
+5. Observar que se muestran los subtítulos aunque estén vacíos.
+
+---
+
+## Multimedia
+
+Adjuntar capturas o grabación del comportamiento si es necesario.

--- a/bug-report-docs/README.md
+++ b/bug-report-docs/README.md
@@ -1,0 +1,94 @@
+# Documentación de Bug Reports
+
+Esta guía contiene las buenas prácticas, estructura y ejemplos necesarios para documentar **Bug Reports** de forma clara, precisa y alineada a la plantilla oficial del equipo. La documentación está dividida en **Frontend** y **Backend**, considerando las particularidades de cada área.
+
+---
+
+## Índice
+
+- [Estructura del Bug Report](#estructura-del-bug-report)
+- [Buenas Prácticas](#buenas-prácticas)
+- [Plantilla Oficial](#plantilla-oficial)
+- [Módulos](#módulos)
+- [Referencias](#referencias)
+
+---
+
+## Objetivos
+
+- Explicar cómo se estructura correctamente un Bug Report.
+- Definir el propósito de cada campo en la plantilla oficial.
+- Presentar ejemplos prácticos bien redactados.
+- Documentar buenas prácticas para priorización y categorización.
+- Brindar una guía útil tanto para frontend como backend.
+
+---
+
+## Estructura del Bug Report
+
+Todo Bug Report debe incluir los siguientes elementos como mínimo:
+
+- **Título del Bug**  
+  ➤ Breve, claro y representativo del problema.
+
+- **Descripción**  
+  ➤ Explicación clara de lo que sucede, cuándo ocurre y bajo qué condiciones.
+
+- **Pasos para Reproducir**  
+  ➤ Instrucciones detalladas para replicar el bug.
+
+- **Resultado Esperado**  
+  ➤ Qué se esperaba que sucediera.
+
+- **Resultado Actual**  
+  ➤ Qué sucedió realmente.
+
+- **Severidad**  
+  ➤ Crítica, Alta, Media o Baja.
+
+- **Prioridad**  
+  ➤ Alta, Media o Baja (según impacto y urgencia).
+
+- **Módulo Afectado**  
+  ➤ Indicar si el bug corresponde a frontend o backend (o ambos).
+
+- **Evidencia**  
+  ➤ Capturas de pantalla, videos o enlaces a reproducción del error.
+
+- **Estado del Bug**  
+  ➤ Abierto, En progreso, Corregido, Cerrado, etc.
+
+---
+
+## Buenas Prácticas
+
+✔ Usar títulos breves pero descriptivos.  
+✔ Detallar pasos reproducibles, incluso si son simples.  
+✔ Evitar lenguaje ambiguo ("a veces falla", "algo no funciona").  
+✔ Priorizar correctamente según impacto.  
+✔ Usar evidencia visual siempre que sea posible.  
+✔ Asegurar que el reporte sea entendible para devs, testers y stakeholders.
+
+---
+
+## Plantilla Oficial
+
+La plantilla oficial se encuentra en la carpeta general y debe utilizarse como base para todo Bug Report.
+
+Archivo: [`Plantilla Bug report.md`](../PlantillaBug.xlsx)
+
+---
+
+## Módulos
+
+La documentación de bugs debe dividirse por módulo según el contexto:
+
+- `frontend/`: Bugs relacionados a la UI o flujos visuales del usuario.
+- `backend/`: Bugs asociados a lógica del servidor, API, validaciones, etc.
+
+Cada módulo contiene:
+
+- `README.md` explicativo con buenas prácticas.
+- Ejemplos reales llenados con la plantilla.
+
+---

--- a/bug-report-docs/backend/BugBackendEjemplo1.md
+++ b/bug-report-docs/backend/BugBackendEjemplo1.md
@@ -1,0 +1,65 @@
+﻿# 🐞 Bug Report - Fallo en creación de usuario por error de validación
+
+## Información General
+
+| Campo               | Detalle                                      |
+|---------------------|----------------------------------------------|
+| **Reportado por**   | QA Loren                                    |
+| **Fecha y Hora**    | 06/28/2024 - 14:15                           |
+| **Área del Problema** | API de Usuarios - Endpoint `/api/users`     |
+| **Título del Problema** | La creación de usuario falla cuando se envían campos vacíos |
+| **Archivos Adjuntos** | Request body, Response JSON, Logs           |
+| **Reproducibilidad** | Siempre                                      |
+| **Hora de Ocurrencia** | 06/28/2024 - 14:15                          |
+| **URL Exacta**       | `https://api.example.com/api/users`         |
+| **Versión de la API** | 2.3.0                                       |
+
+---
+
+## Detalles del Bug
+
+| Acción Realizada | Mensaje de Error |
+|------------------|------------------|
+| Se intentó crear un usuario con un payload donde el campo `email` está vacío. | "El campo email es requerido" |
+
+| Resultado Esperado | Resultado Real |
+|--------------------|----------------|
+| El sistema debe devolver un mensaje de validación clara y evitar la creación. | Se devuelve un error genérico sin detalles de validación. |
+
+---
+
+## Clasificación
+
+| Frecuencia    | Prioridad | Tipo de Defecto |
+|---------------|-----------|-----------------|
+| ☑️ Cada vez   | ☑️ Crítico | ☑️ Backend       |
+
+---
+
+## Pasos para Replicar el Bug
+
+1. Autenticarse con una cuenta admin válida.
+2. Realizar un `POST` al endpoint `/api/users`.
+3. Enviar el siguiente payload con el campo `email` vacío:
+
+```json
+{
+  "name": "Prueba Backend",
+  "email": "loren@prueba.com",
+  "password": "ValidPass123"
+}
+```
+## Observar la respuesta del sistema.
+
+## Multimedia
+
+Adjuntar captura del request y response desde Postman (opcional).
+
+---
+
+## Información del Tester
+
+- **Nombre:** QA Loren
+- **Fecha:** 28/03/2025 – 14:45  
+- **Sistema Operativo:** Windows 11  
+- **Herramienta de Pruebas:** Postman  

--- a/bug-report-docs/backend/BugBackendEjemplo2.md
+++ b/bug-report-docs/backend/BugBackendEjemplo2.md
@@ -1,0 +1,68 @@
+# 🐞 Bug Report - Error en la actualización de datos por formato incorrecto
+
+## Información General
+
+| Campo                | Detalle                                                  |
+|----------------------|----------------------------------------------------------|
+| **Reportado por**    | QA Carlos                                                |
+| **Fecha y Hora**     | 28/03/2025 – 14:45                                       |
+| **Área del Problema**| API de Usuarios - Endpoint `/api/users/:id`             |
+| **Título del Problema** | Error al intentar actualizar un usuario con un campo numérico mal formateado |
+| **Archivos Adjuntos**| Payload de request, capturas del error                   |
+| **Reproducibilidad** | Siempre                                                  |
+| **Hora de Ocurrencia** | 28/03/2025 – 14:45                                     |
+| **URL Exacta**       | `https://api.example.com/api/users/15`                  |
+| **Versión de la API**| 2.3.1                                                    |
+
+---
+
+## Detalles del Bug
+
+| Acción Realizada                                                                 | Mensaje de Error                     |
+|----------------------------------------------------------------------------------|--------------------------------------|
+| Se intentó actualizar un usuario con un campo `age` como string (`"twenty"`)    | "Formato inválido para el campo age" |
+
+| Resultado Esperado                                                               | Resultado Real                                   |
+|----------------------------------------------------------------------------------|--------------------------------------------------|
+| El sistema debería validar el campo y retornar un error 400 con mensaje claro.  | El sistema lanza un error 500 sin explicación.   |
+
+---
+
+## Clasificación
+
+| Frecuencia     | Prioridad | Tipo de Defecto |
+|----------------|-----------|-----------------|
+| ☑️ Cada vez    | ☑️ Medio  | ☑️ Backend       |
+
+---
+
+## Pasos para Replicar el Bug
+
+1. Autenticarse como admin en el entorno de pruebas.
+2. Realizar una solicitud `PUT` al endpoint `/api/users/15`.
+3. Enviar el siguiente payload malformado:
+
+```json
+{
+  "name": "Carlos QA",
+  "email": "carlosqa@example.com",
+  "age": "twenty"
+}
+```
+
+## Observar la respuesta del sistema.
+
+---
+
+## Multimedia
+
+Adjuntar captura de Postman con el request y response (opcional).
+
+---
+
+## Información del Tester
+
+- **Nombre:** Carlos QA  
+- **Fecha:** 28/03/2025 – 14:45  
+- **Sistema Operativo:** Windows 11  
+- **Herramienta de Pruebas:** Postman  

--- a/bug-report-docs/backend/README.md
+++ b/bug-report-docs/backend/README.md
@@ -1,0 +1,63 @@
+# 🐞 Documentación de Bug Reports - Backend
+
+Esta sección está dedicada a la documentación de errores encontrados en el entorno de **backend**, alineada con la plantilla oficial proporcionada por el equipo de QA.
+
+Cada bug report debe reflejar claramente:
+- La acción realizada.
+- El resultado esperado y el real.
+- Clasificación técnica (frecuencia, prioridad, tipo).
+- Pasos detallados para reproducirlo.
+
+---
+
+## Archivos Incluidos
+
+| Archivo                        | Descripción                                                       |
+|-------------------------------|-------------------------------------------------------------------|
+| `BugBackendEjemplo1.md`       | Bug de creación fallida por error de validación.                |
+| `BugBackendEjemplo2.md`       | Error en la actualización de datos por formato incorrecto.       |
+
+---
+
+## Estructura del Bug Report (Backend)
+
+Todo bug debe ser documentado siguiendo esta estructura general:
+
+### Información General
+- Reportado por
+- Fecha y hora
+- Módulo / Servicio afectado
+- Versión del sistema
+
+### Detalles del Bug
+- Acción realizada
+- Mensaje de error (si aplica)
+- Resultado esperado
+- Resultado real
+
+### Clasificación
+- Frecuencia (Cada vez, Ocasional, etc.)
+- Prioridad (Alta, Crítica, Media, etc.)
+- Tipo de Defecto (Backend)
+
+### Pasos para Reproducir
+Listado secuencial de pasos que permitan replicar el error. Incluye herramientas como Postman o capturas de JSON si es necesario.
+
+---
+
+## Buenas Prácticas
+- Ser claro y objetivo al describir la acción.
+- Incluir datos técnicos si es posible: payloads, endpoints, headers.
+- Precisar el error HTTP recibido, si aplica.
+- Adjuntar capturas o ejemplos JSON si ayudan a la reproducción.
+
+---
+
+## Plantilla Referencial
+
+Esta documentación se alinea con el archivo:
+
+[`{Plantilla Bug Report}.md`](../PlantillaBug.md)  
+> Utilizado como referencia estándar.
+
+---

--- a/bug-report-docs/frontend/BugFrontendEjemplo1.md
+++ b/bug-report-docs/frontend/BugFrontendEjemplo1.md
@@ -1,0 +1,45 @@
+﻿## 🐞 Bug Report - Validación de campo obligatorio en formulario
+
+### Información General
+
+| Campo                    | Detalle                                                                 |
+|--------------------------|-------------------------------------------------------------------------|
+| **Reportado por**        | Fernando QA                                                               |
+| **Fecha y Hora**         | 06/27/2024 - 11:00 PM                                                   |
+| **Área del Problema**    | Gestión de Problemas                                                    |
+| **Título del Problema**  | No se muestra mensaje de error al dejar campo obligatorio vacío         |
+| **Archivos Adjuntos**    | Validación, Formulario, UX                                              |
+| **Reproducibilidad**     | Siempre                                                                 |
+| **Hora de Ocurrencia**   | 06/27/2024 - 11:00 PM                                                   |
+| **URL Exacta**           | https://ejemplo.com/app/#/create-problem                                |
+| **Versión de Compilación** | 1.0.0                                                                 |
+
+---
+
+### Detalles del Bug
+
+| Acción Realizada                                                                                         | Mensaje de Error                        |
+|----------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| El usuario intenta enviar el formulario sin llenar el campo "Título".                                    | No aparece ningún mensaje de error.     |
+
+| Resultado Esperado                                                            | Resultado Real                                          |
+|-------------------------------------------------------------------------------|---------------------------------------------------------|
+| Debería mostrarse un mensaje claro: “El título es obligatorio.”              | El formulario se reinicia sin mostrar ninguna advertencia. |
+
+---
+
+### Clasificación
+
+| Frecuencia     | Prioridad | Tipo de Defecto |
+|----------------|-----------|-----------------|
+| ☑️ Cada vez     | ☑️ Crítico | ☑️ Frontend      |
+
+---
+
+### Pasos para Replicar el Bug
+
+1. Iniciar sesión en la plataforma.  
+2. Ir al formulario de creación de problemas.  
+3. Dejar vacío el campo "Título".  
+4. Hacer clic en el botón "Crear Problema".  
+5. Verificar si aparece mensaje de error (no aparece).  

--- a/bug-report-docs/frontend/BugFrontendEjemplo2.md
+++ b/bug-report-docs/frontend/BugFrontendEjemplo2.md
@@ -1,0 +1,46 @@
+﻿## 🐞 Bug Report - Botón “Crear Problema” no responde tras validación
+
+### Información General
+
+| Campo                    | Detalle                                                                                     |
+|--------------------------|---------------------------------------------------------------------------------------------|
+| **Reportado por**        | Lucia QA                                                                                   |
+| **Fecha y Hora**         | 06/27/2024 - 11:45 PM                                                                       |
+| **Área del Problema**    | Gestión de Problemas                                                                        |
+| **Título del Problema**  | El botón “Crear Problema” no funciona después de que se muestra un mensaje de error por campos vacíos |
+| **Archivos Adjuntos**    | Formulario, Validaciones, Navegación                                                       |
+| **Reproducibilidad**     | Siempre                                                                                     |
+| **Hora de Ocurrencia**   | 06/27/2024 - 11:45 PM                                                                       |
+| **URL Exacta**           | https://ejemplo.com/app/#/create-problem                                                    |
+| **Versión de Compilación** | 1.0.0                                                                                     |
+
+---
+
+### Detalles del Bug
+
+| Acción Realizada                                                                                                                                     | Mensaje de Error                                     |
+|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| El usuario intenta crear un problema sin llenar campos requeridos, se muestra el mensaje de error correctamente, pero al llenarlos después y hacer clic en “Crear Problema”, el botón no responde. | No se muestra mensaje nuevo, el botón queda sin funcionalidad. |
+
+| Resultado Esperado                                                                                                 | Resultado Real                                       |
+|--------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| El botón “Crear Problema” debería funcionar una vez que los campos estén completos.                              | El botón permanece inactivo incluso con campos válidos. |
+
+---
+
+### Clasificación
+
+| Frecuencia     | Prioridad | Tipo de Defecto |
+|----------------|-----------|-----------------|
+| ☑️ Cada vez     | ☑️ Alto    | ☑️ Frontend      |
+
+---
+
+### Pasos para Replicar el Bug
+
+1. Iniciar sesión como usuario válido.  
+2. Ir al formulario para crear un nuevo problema.  
+3. Dejar campos requeridos vacíos y hacer clic en "Crear Problema".  
+4. Observar el mensaje de error.  
+5. Llenar los campos requeridos y hacer clic nuevamente.  
+6. Observar que el botón no responde.

--- a/bug-report-docs/frontend/README.md
+++ b/bug-report-docs/frontend/README.md
@@ -1,0 +1,68 @@
+# Bug Reports - Frontend
+
+Esta sección está dedicada a la documentación de **bugs visuales o de comportamiento** en la interfaz de usuario. Se enfoca en errores que el usuario puede notar directamente, como botones que no responden, validaciones rotas o renderizado incorrecto.
+
+---
+
+## Objetivo
+
+Brindar una guía clara para documentar bugs detectados en el frontend, con ejemplos y buenas prácticas alineadas a la plantilla oficial del equipo.
+
+---
+
+## Estructura de un Bug Report (Frontend)
+
+- **Título del Bug**  
+  ➤ Breve y directo, describiendo el error (Ej: “Botón 'Guardar' no responde”).
+
+- **Descripción**  
+  ➤ ¿Qué pasa? ¿Dónde ocurre? ¿Con qué frecuencia?
+
+- **Pasos para Reproducir**  
+  ➤ Instrucciones paso a paso desde el login hasta el error.
+
+- **Resultado Esperado**  
+  ➤ Qué debería haber ocurrido si todo funcionaba correctamente.
+
+- **Resultado Actual**  
+  ➤ Qué está ocurriendo en realidad (puede incluir screenshots o gifs).
+
+- **Módulo Afectado**  
+  ➤ Indicar si pertenece a login, perfil, editor, etc.
+
+- **Severidad y Prioridad**  
+  ➤ Según el impacto visual, la funcionalidad y frecuencia.
+
+- **Evidencia Visual**  
+  ➤ Capturas de pantalla, videos o enlaces a Drive.
+
+---
+
+## Buenas Prácticas
+
+✔ Usa lenguaje técnico pero comprensible.  
+✔ Describe la ubicación exacta del bug en la interfaz.  
+✔ Si es un bug intermitente, indícalo.  
+✔ Siempre incluye pasos precisos.  
+✔ Usa capturas claras con círculos, flechas o marcas si es necesario.  
+✔ Indica navegador, sistema operativo y resolución si es relevante.  
+✔ No olvides revisar si el bug ya ha sido reportado.
+
+---
+
+## Ejemplos
+
+En esta carpeta encontrarás ejemplos documentados en formato `.md`:
+
+- `BugFrontendEjemplo1.md`: Error en campo obligatorio.  
+- `BugFrontendEjemplo2.md`: Fallo al cambiar de tab.  
+
+---
+
+## Plantilla Base
+
+Usa la plantilla oficial para documentar los bugs:
+
+[`Plantilla Bug Report.md`](../PlantillaBug.md)
+
+---


### PR DESCRIPTION
## **This pull request completes the documentation for task #69 - Bug Report Documentation.**

### What's included:
- General guide on how to write a Bug Report using the team's template.
- Explanation of each field in the report and how to fill it properly.
- Best practices for writing.